### PR TITLE
Fix first response error

### DIFF
--- a/main.go
+++ b/main.go
@@ -216,6 +216,9 @@ func writeAndRead(port serial.Port, b []byte) ([]byte, error) {
 		}
 		result = append(result, buff[:n]...)
 	}
+	if len(result) == 0 {
+		return nil, fmt.Errorf("no response")
+	}
 	if !verifyReceivedContainer(result) {
 		return nil, fmt.Errorf("invalid response")
 	}


### PR DESCRIPTION
Fix a first response error.

Fix an error when executing a command for the first time after the M5Stack device has been booted.
