### PR TITLE
Improve upload performance

### DIFF
--- a/main.go
+++ b/main.go
@@ -292,6 +292,14 @@ func createCommand(command int8, data string) []byte {
 }
 
 func verifyReceivedContainer(data []byte) bool {
+	/*
+	 * header(3)
+	 * command(1)
+	 * result(1) 0x00=ok probably
+	 * data(*)
+	 * crc16(2) crc16(head+command+result+data)
+	 * footer(3)
+	 */
 	head := [...]byte{0xaa, 0xab, 0xaa}
 	foot := [...]byte{0xab, 0xcc, 0xab}
 	return reflect.DeepEqual(data[0:3], head[:]) && reflect.DeepEqual(data[len(data)-3:], foot[:])


### PR DESCRIPTION
Improve upload performance

Upload (put) command was very slow as it waited for a response timeout.
Add `writeAndReadBriskly` function. This function doesn't wait for the timeout. When a buffer of a specific size is filled, it returns data without waiting for the timeout.
